### PR TITLE
Switch to using RELIABLE_DEBUG instead of NDEBUG

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -15,11 +15,12 @@ solution "reliable"
     vectorextensions "SSE2"
         configuration "Debug"
         symbols "On"
+        defines { "RELIABLE_DEBUG" }
         links { debug_libs }
     configuration "Release"
         symbols "Off"
         optimize "Speed"
-        defines { "NDEBUG" }
+        defines { "RELIABLE_RELEASE" }
         links { release_libs }
     configuration { "gmake" }
         linkoptions { "-lm" }    

--- a/reliable.c
+++ b/reliable.c
@@ -1491,7 +1491,7 @@ static void check_handler( RELIABLE_CONST char * condition,
                            int line )
 {
     printf( "check failed: ( %s ), function %s, file %s, line %d\n", condition, function, file, line );
-#ifndef NDEBUG
+#ifdef RELIABLE_DEBUG
     #if defined( __GNUC__ )
         __builtin_trap();
     #elif defined( _MSC_VER )

--- a/reliable.h
+++ b/reliable.h
@@ -27,6 +27,16 @@
 
 #include <stdint.h>
 
+#if !defined(RELIABLE_DEBUG) && !defined(RELIABLE_RELEASE)
+#if defined(NDEBUG)
+#define RELIABLE_RELEASE
+#else
+#define RELIABLE_DEBUG
+#endif
+#elif defined(RELIABLE_DEBUG) && defined(RELIABLE_RELEASE)
+#error Can only define one of debug & release
+#endif
+
 #if    defined(__386__) || defined(i386)    || defined(__i386__)  \
     || defined(__X86)   || defined(_M_IX86)                       \
     || defined(_M_X64)  || defined(__x86_64__)                    \
@@ -139,7 +149,7 @@ void reliable_set_printf_function( int (*function)( RELIABLE_CONST char *, ... )
 
 extern void (*netcode_assert_function)( RELIABLE_CONST char *, RELIABLE_CONST char *, RELIABLE_CONST char * file, int line );
 
-#ifndef NDEBUG
+#ifdef RELIABLE_DEBUG
 #define reliable_assert( condition )                                                        \
 do                                                                                          \
 {                                                                                           \

--- a/soak.c
+++ b/soak.c
@@ -100,7 +100,7 @@ static void check_handler( char * condition,
                            int line )
 {
     printf( "check failed: ( %s ), function %s, file %s, line %d\n", condition, function, file, line );
-#ifndef NDEBUG
+#ifdef RELIABLE_DEBUG
     #if defined( __GNUC__ )
         __builtin_trap();
     #elif defined( _MSC_VER )

--- a/stats.c
+++ b/stats.c
@@ -101,7 +101,7 @@ static void check_handler( char * condition,
                            int line )
 {
     printf( "check failed: ( %s ), function %s, file %s, line %d\n", condition, function, file, line );
-#ifndef NDEBUG
+#ifdef RELIABLE_DEBUG
     #if defined( __GNUC__ )
         __builtin_trap();
     #elif defined( _MSC_VER )


### PR DESCRIPTION
This allows folks to control whether to use debug features on a
per-project basis.  If neither is specified, NDEBUG controls the
behavior, so no changes needed for anyone who's using this library.